### PR TITLE
Add a getter to expose the name used to construct a queue.

### DIFF
--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -177,11 +177,17 @@ public class Queue {
 
     /**
      * Clears the queue off all messages
-     * @param queue the name of the queue 
      * @throws IOException
      */
     public void clear() throws IOException {
         client.post("queues/"+name+"/clear", "").close();
+    }
+
+    /**
+     * @return the name of this queue
+     */
+    public String getName() {
+        return name;
     }
 
     static class Info implements Serializable {


### PR DESCRIPTION
Change for Issue #26.

Also remove an obsolete param comment from clear().
