### PR TITLE
Create/update queue fixes

### DIFF
--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -683,24 +683,6 @@ public class Queue {
         reader.close();
     }
 
-    static class UpdateQueue {
-        private String pushType;
-        private int retries;
-        private int retries_delay;
-        private String error_queue;
-        private ArrayList<Subscriber> subscribers;
-        private ArrayList<Alert> alerts;
-
-        public UpdateQueue(ArrayList<Subscriber> subscribers, ArrayList<Alert> alerts, String pushType, String errorQueue, int retries, int retriesDelay) {
-            this.subscribers = subscribers;
-            this.alerts = alerts;
-            this.pushType = pushType;
-            this.error_queue = errorQueue;
-            this.retries = retries;
-            this.retries_delay = retriesDelay;
-        }
-    }
-
     /**
      * Creates a queue for specified queue client.
      * If queue exists, it will be updated.
@@ -726,14 +708,11 @@ public class Queue {
      * @throws IOException If there is an error accessing the IronMQ server.
      */
     public QueueModel create(ArrayList<Subscriber> subscribersList, ArrayList<Alert> alertsList, String pushType, String errorQueue, int retries, int retriesDelay) throws IOException {
-        String url = "queues/" + name;
-        UpdateQueue updateQueue = new UpdateQueue(subscribersList, alertsList, pushType, errorQueue, retries, retriesDelay);
-        Gson gson = new Gson();
-        String jsonMessages = gson.toJson(updateQueue);
-        Reader reader = client.put(url, jsonMessages);
-        QueueModel message = gson.fromJson(reader, QueueModel.class);
-        reader.close();
-        return message;
+        QueueModel model = new QueueModel();
+        model.setPushInfo(new QueuePushModel(subscribersList, retries, retriesDelay, errorQueue));
+        model.setAlerts(alertsList);
+        model.setType(pushType);
+        return create(model);
     }
 
     /**
@@ -752,6 +731,24 @@ public class Queue {
     }
 
     /**
+     * Creates a queue for specified queue client.
+     * If queue exists, it will be updated.
+     * @param model QueueModel instance with desired parameters of queue
+     * @throws HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws IOException If there is an error accessing the IronMQ server.
+     */
+    public QueueModel create(QueueModel model) throws IOException {
+        String url = "queues/" + name;
+        QueueContainer payload = new QueueContainer(model);
+
+        Gson gson = new Gson();
+        Reader reader = client.put(url, gson.toJson(payload));
+        QueueContainer container = gson.fromJson(reader, QueueContainer.class);
+        reader.close();
+        return container.getQueue();
+    }
+
+    /**
      * Update queue. If there is no queue, an EmptyQueueException is thrown.
      * @param subscribersList The subscribers list.
      * @param alertsList The alerts list.
@@ -763,14 +760,11 @@ public class Queue {
      * @throws IOException If there is an error accessing the IronMQ server.
      */
     public QueueModel updateQueue(ArrayList<Subscriber> subscribersList, ArrayList<Alert> alertsList, String pushType, String errorQueue, int retries, int retriesDelay) throws IOException {
-        String url = "queues/" + name;
-        UpdateQueue updateQueue = new UpdateQueue(subscribersList, alertsList, pushType, errorQueue, retries, retriesDelay);
-        Gson gson = new Gson();
-        String jsonMessages = gson.toJson(updateQueue);
-        Reader reader = client.patch(url, jsonMessages);
-        QueueModel message = gson.fromJson(reader, QueueModel.class);
-        reader.close();
-        return message;
+        QueueModel model = new QueueModel();
+        model.setPushInfo(new QueuePushModel(subscribersList, retries, retriesDelay, errorQueue));
+        model.setAlerts(alertsList);
+        model.setType(pushType);
+        return update(model);
     }
 
     /**

--- a/src/test/java/io/iron/ironmq/IronMQTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQTest.java
@@ -592,6 +592,60 @@ public class IronMQTest {
     }
 
     @Test
+    public void testCreateQueueWithParams() throws IOException {
+        String name = "my_queue_" + ts();
+        Queue queue = new Queue(client, name);
+
+        QueueModel payload = new QueueModel();
+        payload.setMessageTimeout(69);
+        payload.setMessageExpiration(404);
+        QueueModel info = queue.update(payload);
+
+        Assert.assertEquals(69, info.getMessageTimeout());
+        Assert.assertEquals(404, info.getMessageExpiration());
+    }
+
+    @Test
+    public void testCreateQueueOverload2() throws IOException {
+        String name = "my_queue_" + ts();
+        Queue queue = new Queue(client, name);
+
+        ArrayList<Subscriber> subs = new ArrayList<Subscriber>(){{ add(new Subscriber("http://localhost:3000/", "test")); }};
+
+        QueueModel response = queue.create(subs, null, "multicast", 5, 3);
+        Assert.assertEquals(name, response.getName());
+        Assert.assertEquals(60, response.getMessageTimeout());
+        Assert.assertEquals("multicast", response.getType());
+        Assert.assertEquals(5, response.getPushInfo().getRetries().intValue());
+        Assert.assertEquals(3, response.getPushInfo().getRetriesDelay().intValue());
+        Assert.assertEquals(1, response.getPushInfo().getSubscribers().size());
+
+        QueueModel info = queue.getInfoAboutQueue();
+        Assert.assertEquals(name, info.getName());
+    }
+
+
+    @Test
+    public void testCreateQueueOverload3() throws IOException {
+        String name = "my_queue_" + ts();
+        Queue queue = new Queue(client, name);
+
+        ArrayList<Subscriber> subs = new ArrayList<Subscriber>(){{ add(new Subscriber("http://localhost:3000/", "test")); }};
+
+        QueueModel response = queue.create(subs, null, "multicast", "err_q", 5, 3);
+        Assert.assertEquals(name, response.getName());
+        Assert.assertEquals(60, response.getMessageTimeout());
+        Assert.assertEquals("multicast", response.getType());
+        Assert.assertEquals(5, response.getPushInfo().getRetries().intValue());
+        Assert.assertEquals(3, response.getPushInfo().getRetriesDelay().intValue());
+        Assert.assertEquals("err_q", response.getPushInfo().getErrorQueue());
+        Assert.assertEquals(1, response.getPushInfo().getSubscribers().size());
+
+        QueueModel info = queue.getInfoAboutQueue();
+        Assert.assertEquals(name, info.getName());
+    }
+
+    @Test
     public void testUpdateQueue() throws IOException {
         String name = "my_queue_" + ts();
         Queue queue = new Queue(client, name);


### PR DESCRIPTION
- updateQueue must use PATCH method instead of POST
- add create overloads that accept queue type, since otherwise it is impossible
  to create push queues

updateQueue overloads with pushType should probably be deprecated since
pushType can never change, but I haven't done that in this commit.
