### PR TITLE
add possibility to look for iron.json in parent directories

### DIFF
--- a/src/main/java/io/iron/ironmq/Client.java
+++ b/src/main/java/io/iron/ironmq/Client.java
@@ -301,7 +301,7 @@ public class Client {
 
         for (String suffix : suffixes) {
             for (String configBase : new String[]{company + "-" + product, company + "_" + product, company}) {
-                if (true || lookUpLimit > 0) {
+                if (lookUpLimit > 0) {
                     File parent = new File(System.getProperty("user.dir")).getParentFile();
                     for (int i = lookUpLimit; i > 0 && parent !=null; i--) {
                         String name = parent.getAbsolutePath();

--- a/src/test/java/io/iron/ironmq/IronMQTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQTest.java
@@ -20,7 +20,7 @@ public class IronMQTest {
 
     @Before
     public void setUp() throws Exception {
-        client = new Client(null, null, null, 3, 2);
+        client = new Client(null, null, null, 3, 1);
     }
 
     /**


### PR DESCRIPTION
Add possibility to look for iron.json in parent folders.

It's needed for publishing to maven: maven takes source from git and this source hasn't iron.json file. So one possible way is to place iron.json in ../../ folder and let Client in unit-tests to search for it in parent directories.

``` java
int level = 2;  // equivalent of ../../
int apiVersion = 3;
client = new Client(null, null, null, apiVersion, level);
```

This feature does not violate the existing interfaces.
