### PR TITLE
update touchMessage according to new response structure

### DIFF
--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -191,8 +191,10 @@ public class Queue {
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
-    public void touchMessage(Message message) throws IOException {
-        touchMessage(message.getId(), message.getReservationId());
+    public MessageOptions touchMessage(Message message) throws IOException {
+        MessageOptions messageOptions = touchMessage(message.getId(), message.getReservationId());
+        message.setReservationId(messageOptions.getReservationId());
+        return messageOptions;
     }
 
     /**
@@ -203,10 +205,14 @@ public class Queue {
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
-    public void touchMessage(String id, String reservationId) throws IOException {
+    public MessageOptions touchMessage(String id, String reservationId) throws IOException {
         String payload = new Gson().toJson(new MessageOptions(reservationId));
         IronReader reader = client.post("queues/" + name + "/messages/" + id + "/touch", payload);
-        reader.close();
+        try {
+            return new Gson().fromJson(reader.reader, MessageOptions.class);
+        } finally {
+            reader.close();
+        }
     }
 
     /**

--- a/src/test/java/io/iron/ironmq/IronMQTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQTest.java
@@ -346,6 +346,29 @@ public class IronMQTest {
     }
 
     /**
+     * Test shows how to touch a message multiple times.
+     * Expected that:
+     * - after second touch call message will have new reservation id
+     * - new reservation id will not equal to old one
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Test
+    public void testTouchMessageTwice() throws IOException, InterruptedException {
+        Queue queue = new Queue(client, "my_queue_" + ts());
+        queue.push("Test message");
+        Message message = queue.reserve(1, 5).getMessage(0);
+
+        Thread.sleep(3500);
+        MessageOptions options1 = queue.touchMessage(message);
+        Thread.sleep(3500);
+        MessageOptions options2 = queue.touchMessage(message);
+
+        Assert.assertFalse(options1.getReservationId().equals(options2.getReservationId()));
+        Assert.assertEquals(message.getReservationId(), options2.getReservationId());
+    }
+
+    /**
      * This test shows how to release a message back to queue if, for example, it could not be processed
      * Expected that:
      * - Message should return to the queue and be available for reserving


### PR DESCRIPTION
- `touchMessage(String id, String reservationId)` and `touchMessage(Message message)` now return MessageOptions instance with reservationId. I decided to return not only string because we probably will decide to return something else
- `touchMessage(Message message)` also rewrites old `reservationId` in `message`
- deprecated `touchMessage(String id)` left as it was because it doesn't work due to lack of reservation_id. this method left only for backward compatibility
