### PR TITLE
Resolve V3 inconsistency

### DIFF
--- a/src/main/java/io/iron/ironmq/Cloud.java
+++ b/src/main/java/io/iron/ironmq/Cloud.java
@@ -9,10 +9,7 @@ public class Cloud {
     int port;
     String pathPrefix = "";
 
-    public static final Cloud ironAWSUSEast = new Cloud("https", "mq-aws-us-east-1.iron.io", 443);
-    public static final Cloud ironAWSEUWest = new Cloud("https", "mq-aws-eu-west-1.iron.io", 443);
-    public static final Cloud ironRackspaceORD = new Cloud("https", "mq-rackspace-ord.iron.io", 443);
-    public static final Cloud ironRackspaceLON = new Cloud("https", "mq-rackspace-lon.iron.io", 443);
+    public static final Cloud ironAWSUSEast = new Cloud("https", "mq-v3-aws-us-east-1.iron.io", 443);
 
     public Cloud(String url) throws MalformedURLException {
         URL u = new URL(url);

--- a/src/main/java/io/iron/ironmq/Message.java
+++ b/src/main/java/io/iron/ironmq/Message.java
@@ -9,7 +9,6 @@ import com.google.gson.annotations.SerializedName;
  */
 public class Message extends MessageOptions implements Serializable {
     private String body;
-    private long timeout;
     // Long, not long, so that it's nullable. Gson doesn't serialize null,
     // so we can use the default on the server and not have to know about
     // it.
@@ -29,18 +28,6 @@ public class Message extends MessageOptions implements Serializable {
     * @param body The new body contents.
     */
     public void setBody(String body) { this.body = body; }
-
-    /**
-    * Returns the Message's timeout.
-    */
-    public long getTimeout() { return timeout; }
-
-    /**
-    * Sets the Message's timeout.
-    *
-    * @param timeout The new timeout.
-    */
-    public void setTimeout(long timeout) { this.timeout = timeout; }
 
     /**
      * Returns the number of times the message has been reserved.

--- a/src/main/java/io/iron/ironmq/MessageOptions.java
+++ b/src/main/java/io/iron/ironmq/MessageOptions.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 public class MessageOptions implements Serializable {
     protected String id;
     protected Long delay;
+    private Long timeout;
 
     @SerializedName("reservation_id")
     protected String reservationId;
@@ -31,6 +32,12 @@ public class MessageOptions implements Serializable {
         this.reservationId = reservationId;
     }
 
+    public MessageOptions(String id, String reservationId, Long timeout) {
+        this.id = id;
+        this.reservationId = reservationId;
+        this.timeout = timeout;
+    }
+
     /**
      * Returns Id of the Message.
      */
@@ -49,6 +56,11 @@ public class MessageOptions implements Serializable {
      * Returns the number of seconds after which the Message will be available.
      */
     public long getDelay() { return delay; }
+
+    /**
+     * Returns the Message's timeout.
+     */
+    public long getTimeout() { return timeout; }
 
     /**
      * Sets Id to the Message.
@@ -74,4 +86,11 @@ public class MessageOptions implements Serializable {
      * @param delay The new delay.
      */
     public void setDelay(long delay) { this.delay = delay; }
+
+    /**
+     * Sets the Message's timeout.
+     *
+     * @param timeout The new timeout.
+     */
+    public void setTimeout(long timeout) { this.timeout = timeout; }
 }

--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -172,27 +172,39 @@ public class Queue {
     /**
      * Touching a reserved message extends its timeout to the duration specified when the message was created.
      *
-     * @param id The ID of the message to delete.
-     *
-     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
-     * @throws java.io.IOException If there is an error accessing the IronMQ server.
-     * @deprecated It's not possible to touch a message without reservation id since v3 of IronMQ
-     */
-    @Deprecated
-    public void touchMessage(String id) throws IOException {
-        touchMessage(id, null);
-    }
-
-    /**
-     * Touching a reserved message extends its timeout to the duration specified when the message was created.
-     *
      * @param message The message to delete.
      *
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
     public MessageOptions touchMessage(Message message) throws IOException {
-        MessageOptions messageOptions = touchMessage(message.getId(), message.getReservationId());
+        return touchMessage(message, null);
+    }
+
+    /**
+     * Touching a reserved message extends its timeout to the specified duration.
+     *
+     * @param message The message to delete.
+     * @param timeout After timeout (in seconds), item will be placed back onto queue.
+     *
+     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws java.io.IOException If there is an error accessing the IronMQ server.
+     */
+    public MessageOptions touchMessage(Message message, int timeout) throws IOException {
+        return touchMessage(message, (long) timeout);
+    }
+
+    /**
+     * Touching a reserved message extends its timeout to the duration specified when the message was created.
+     *
+     * @param message The message to delete.
+     * @param timeout After timeout (in seconds), item will be placed back onto queue.
+     *
+     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws java.io.IOException If there is an error accessing the IronMQ server.
+     */
+    public MessageOptions touchMessage(Message message, Long timeout) throws IOException {
+        MessageOptions messageOptions = touchMessage(message.getId(), message.getReservationId(), timeout);
         message.setReservationId(messageOptions.getReservationId());
         return messageOptions;
     }
@@ -201,12 +213,41 @@ public class Queue {
      * Touching a reserved message extends its timeout to the duration specified when the message was created.
      *
      * @param id The ID of the message to delete.
+     * @param reservationId This id is returned when you reserve a message and must be provided to delete a message that is reserved.
      *
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
     public MessageOptions touchMessage(String id, String reservationId) throws IOException {
-        String payload = new Gson().toJson(new MessageOptions(reservationId));
+        return touchMessage(id, reservationId, null);
+    }
+
+    /**
+     * Touching a reserved message extends its timeout to the specified duration.
+     *
+     * @param id The ID of the message to delete.
+     * @param reservationId This id is returned when you reserve a message and must be provided to delete a message that is reserved.
+     * @param timeout After timeout (in seconds), item will be placed back onto queue.
+     *
+     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws java.io.IOException If there is an error accessing the IronMQ server.
+     */
+    public MessageOptions touchMessage(String id, String reservationId, int timeout) throws IOException {
+        return touchMessage(id, reservationId, (long) timeout);
+    }
+
+    /**
+     * Touching a reserved message extends its timeout to the duration specified when the message was created.
+     *
+     * @param id The ID of the message to delete.
+     * @param reservationId This id is returned when you reserve a message and must be provided to delete a message that is reserved.
+     * @param timeout After timeout (in seconds), item will be placed back onto queue.
+     *
+     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws java.io.IOException If there is an error accessing the IronMQ server.
+     */
+    public MessageOptions touchMessage(String id, String reservationId, Long timeout) throws IOException {
+        String payload = new Gson().toJson(new MessageOptions(null, reservationId, timeout));
         IronReader reader = client.post("queues/" + name + "/messages/" + id + "/touch", payload);
         try {
             return new Gson().fromJson(reader.reader, MessageOptions.class);

--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -278,7 +278,20 @@ public class Queue {
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
     public void deleteMessage(String id, String reservationId) throws IOException {
-        String payload = new Gson().toJson(new MessageOptions(reservationId));
+        deleteMessage(id, reservationId, null);
+    }
+
+    /**
+     * Deletes a Message from the queue.
+     *
+     * @param id The ID of the message to delete.
+     * @param reservationId Reservation Id of the message. Reserved message could not be deleted without reservation Id.
+     *
+     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws java.io.IOException If there is an error accessing the IronMQ server.
+     */
+    public void deleteMessage(String id, String reservationId, String subscriberName) throws IOException {
+        String payload = new Gson().toJson(new SubscribedMessageOptions(reservationId, subscriberName));
         IronReader reader = client.delete("queues/" + name + "/messages/" + id, payload);
         reader.close();
     }
@@ -693,14 +706,13 @@ public class Queue {
     /**
      * Delete push message for subscriber by subscriber ID and message ID. If there is no message or subscriber,
      * an EmptyQueueException is thrown.
-     * @param subscriberId The Subscriber ID.
+     * @param subscriberName The name of Subscriber.
      * @param messageId The Message ID.
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
-    public void deletePushMessageForSubscriber(String messageId, String subscriberId) throws  IOException {
-        IronReader reader = client.delete("queues/" + name + "/messages/" + messageId + "/subscribers/" + subscriberId);
-        reader.close();
+    public void deletePushMessageForSubscriber(String messageId, String subscriberName) throws  IOException {
+        deleteMessage(messageId, null, subscriberName);
     }
 
     /**

--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -505,22 +505,6 @@ public class Queue {
      * Release reserved message after specified time. If there is no message with such id on the queue, an
      * EmptyQueueException is thrown.
      *
-     * @param id The ID of the message to release.
-     * @param delay The time after which the message will be released.
-     *
-     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
-     * @throws java.io.IOException If there is an error accessing the IronMQ server.
-     * @deprecated Reservation Id is required for message releasing since v3
-     */
-    @Deprecated
-    public void releaseMessage(String id, int delay) throws IOException {
-        releaseMessage(id, null, new Long(delay));
-    }
-
-    /**
-     * Release reserved message after specified time. If there is no message with such id on the queue, an
-     * EmptyQueueException is thrown.
-     *
      * @param message The message to release.
      *
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.

--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -711,8 +711,8 @@ public class Queue {
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
-    public void deletePushMessageForSubscriber(String messageId, String subscriberName) throws  IOException {
-        deleteMessage(messageId, null, subscriberName);
+    public void deletePushMessageForSubscriber(String messageId, String reservationId, String subscriberName) throws  IOException {
+        deleteMessage(messageId, reservationId, subscriberName);
     }
 
     /**

--- a/src/main/java/io/iron/ironmq/Queue.java
+++ b/src/main/java/io/iron/ironmq/Queue.java
@@ -550,18 +550,6 @@ public class Queue {
      * @param subscribersList The array list of subscribers.
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
-     * @deprecated Use updateSubscribers instead
-     */
-    @Deprecated
-    public void addSubscribersToQueue(ArrayList<Subscriber> subscribersList) throws IOException {
-        this.updateSubscribers(subscribersList);
-    }
-
-    /**
-     * Add subscribers to Queue. If there is no queue, an EmptyQueueException is thrown.
-     * @param subscribersList The array list of subscribers.
-     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
-     * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
     public void addSubscribers(ArrayList<Subscriber> subscribersList) throws IOException {
         addSubscribers(new Subscribers(subscribersList));
@@ -590,14 +578,33 @@ public class Queue {
     }
 
     /**
-     * Add subscribers to Queue. If there is no queue, an EmptyQueueException is thrown.
+     * Update old or add new subscribers to Queue. If there is no queue, an EmptyQueueException is thrown.
      * @param subscribersList The array list of subscribers.
      * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
      * @throws java.io.IOException If there is an error accessing the IronMQ server.
      */
-    public QueueModel updateSubscribers(ArrayList<Subscriber> subscribersList) throws IOException {
-        QueueModel payload = new QueueModel(new QueuePushModel(subscribersList));
-        return this.update(payload);
+    public void updateSubscribers(ArrayList<Subscriber> subscribersList) throws IOException {
+        addSubscribers(subscribersList);
+    }
+
+    /**
+     * Update old or add new subscribers to Queue. If there is no queue, an EmptyQueueException is thrown.
+     * @param subscribers The array of subscribers.
+     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws java.io.IOException If there is an error accessing the IronMQ server.
+     */
+    public void updateSubscribers(Subscriber[] subscribers) throws IOException {
+        addSubscribers(subscribers);
+    }
+
+    /**
+     * Update old or add new subscribers to Queue. If there is no queue, an EmptyQueueException is thrown.
+     * @param subscribers The array of subscribers.
+     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
+     * @throws java.io.IOException If there is an error accessing the IronMQ server.
+     */
+    public void updateSubscribers(Subscribers subscribers) throws IOException {
+        addSubscribers(subscribers);
     }
 
     /**
@@ -632,22 +639,6 @@ public class Queue {
     public void replaceSubscribers(Subscribers subscribers) throws IOException {
         String payload = new Gson().toJson(subscribers);
         IronReader reader = client.put("queues/" + name + "/subscribers", payload);
-        reader.close();
-    }
-
-
-    /**
-     * Remove subscribers from Queue. If there is no queue, an EmptyQueueException is thrown.
-     * @param subscribersList The array list of subscribers.
-     * @throws io.iron.ironmq.HTTPException If the IronMQ service returns a status other than 200 OK.
-     * @throws java.io.IOException If there is an error accessing the IronMQ server.
-     */
-    public void removeSubscribersFromQueue(ArrayList<Subscriber> subscribersList) throws IOException {
-        String url = "queues/" + name + "/subscribers";
-        Subscribers subscribers = new Subscribers(subscribersList);
-        Gson gson = new Gson();
-        String jsonMessages = gson.toJson(subscribers);
-        IronReader reader = client.delete(url, jsonMessages);
         reader.close();
     }
 

--- a/src/main/java/io/iron/ironmq/SubscribedMessageOptions.java
+++ b/src/main/java/io/iron/ironmq/SubscribedMessageOptions.java
@@ -1,0 +1,45 @@
+package io.iron.ironmq;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+/**
+ * The Message class represents a message retrieved from an IronMQ queue.
+ */
+public class SubscribedMessageOptions extends MessageOptions {
+    @SerializedName("subscriber_name")
+    protected String subscriberName;
+
+    public SubscribedMessageOptions() {
+    }
+
+    public SubscribedMessageOptions(String reservationId, String subscriberName) {
+        super(reservationId);
+        this.subscriberName = subscriberName;
+    }
+
+    public SubscribedMessageOptions(String id, String reservationId, String subscriberName) {
+        super(id, reservationId);
+        this.subscriberName = subscriberName;
+    }
+
+    public SubscribedMessageOptions(String id, String reservationId, Long timeout, String subscriberName) {
+        super(id, reservationId, timeout);
+        this.subscriberName = subscriberName;
+    }
+
+    /**
+     * Returns the name of Message's Subscriber.
+     */
+    public String getSubscriberName() {
+        return subscriberName;
+    }
+
+    /**
+     * Sets the name of Message's Subscriber.
+     */
+    public void setSubscriberName(String subscriberName) {
+        this.subscriberName = subscriberName;
+    }
+}

--- a/src/test/java/io/iron/ironmq/IronMQLongRunningTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQLongRunningTest.java
@@ -1,0 +1,118 @@
+package io.iron.ironmq;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.sound.midi.VoiceStatus;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Properties;
+
+public class IronMQLongRunningTest {
+    private String queueName = "java-testing-queue";
+    private Client client;
+    private Queue queue;
+
+    @Before
+    public void setUp() throws Exception {
+        client = new Client(null, null, null, 3, 1);
+        queue = new Queue(client, "my_queue_" + ts());
+    }
+
+    /**
+     * Test shows how to increase time of message reservation
+     * Expected that:
+     * - message will be available after 30 seconds (initial timeout is 30 seconds)
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Test
+    public void testReserveMessageWithTimeout() throws IOException, InterruptedException {
+        queue.push("Test message");
+        Message reservedFirstTime = queue.reserve(1, 30).getMessage(0);
+
+        Thread.sleep(32000);
+        Messages reservedAgain = queue.reserve(1);
+        Assert.assertEquals(1, reservedAgain.getSize());
+        Assert.assertEquals(reservedAgain.getMessage(0).getId(), reservedFirstTime.getId());
+    }
+
+    /**
+     * Test shows how to increase time of message reservation
+     * Expected that:
+     * - message will not be available after 35 seconds (initial timeout is 30 seconds)
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Test
+    public void testTouchMessage() throws IOException, InterruptedException {
+        queue.push("Test message");
+        Message message = queue.reserve(1, 30).getMessage(0);
+
+        Thread.sleep(25000);
+        queue.touchMessage(message);
+        Thread.sleep(10000);
+        Assert.assertEquals(0, queue.reserve(1).getSize());
+    }
+
+    /**
+     * Test shows how to increase time of message reservation by specified amount of seconds
+     * Expected that:
+     * - message will be available only after specified amount of seconds.
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Test
+    public void testTouchMessageWithTimeout() throws IOException, InterruptedException {
+        queue.push("Test message");
+        Message message = queue.reserve(1, 30).getMessage(0);
+        queue.touchMessage(message, 40);
+
+        Thread.sleep(35000);
+        Assert.assertEquals(0, queue.reserve(1).getSize());
+        Thread.sleep(10000);
+        Assert.assertEquals(1, queue.reserve(1).getSize());
+    }
+
+    /**
+     * Test shows how to touch a message multiple times.
+     * Expected that:
+     * - after second touch call message will have new reservation id
+     * - new reservation id will not equal to old one
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Test
+    public void testTouchMessageTwice() throws IOException, InterruptedException {
+        queue.push("Test message");
+        Message message = queue.reserve(1, 5).getMessage(0);
+
+        Thread.sleep(3500);
+        MessageOptions options1 = queue.touchMessage(message);
+        Thread.sleep(3500);
+        MessageOptions options2 = queue.touchMessage(message);
+
+        Assert.assertFalse(options1.getReservationId().equals(options2.getReservationId()));
+        Assert.assertEquals(message.getReservationId(), options2.getReservationId());
+    }
+
+    private long ts() {
+        return new Date().getTime();
+    }
+
+    private Queue createQueueWithMessage(String queueName) throws IOException {
+        Queue queue = new Queue(client, queueName);
+        queue.push("Test message");
+        return queue;
+    }
+
+    private String repeatString(String s, int times) {
+        return new String(new char[times]).replace("\0", s);
+    }
+}

--- a/src/test/java/io/iron/ironmq/IronMQTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQTest.java
@@ -414,25 +414,6 @@ public class IronMQTest {
     }
 
     /**
-     * This test shows that a reserved message could not be released without a reservation id
-     * Note:
-     * - queue.releaseMessage(id, delay) has been deprecated
-     * - reserved message can't be touched without reservation id as well
-     * Expected:
-     * - HTTPException (403) Wrong reservation_id
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Test(expected = HTTPException.class)
-    public void testReleaseMessageWithoutReservationId() throws IOException, InterruptedException {
-        queue.push("Test message");
-        Message message = queue.reserve(1, 5).getMessage(0);
-
-        Thread.sleep(500);
-        queue.releaseMessage(message.getId(), 0);
-    }
-
-    /**
      * This test shows old way of listing queues. Don't use it.
      * @throws IOException
      */

--- a/src/test/java/io/iron/ironmq/IronMQTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQTest.java
@@ -474,7 +474,7 @@ public class IronMQTest {
      */
     @Test(expected = HTTPException.class)
     public void testGetInfoBeforeQueueCreated() throws IOException {
-        QueueModel info = queue.getInfoAboutQueue();
+        queue.getInfoAboutQueue();
     }
 
     /**
@@ -572,9 +572,6 @@ public class IronMQTest {
      */
     @Test
     public void testUpdateQueue() throws IOException {
-        String name = "my_queue_" + ts();
-        Queue queue = new Queue(client, name);
-
         QueueModel payload = new QueueModel();
         payload.setMessageTimeout(69);
         QueueModel info = queue.update(payload);
@@ -590,9 +587,6 @@ public class IronMQTest {
      */
     @Test
     public void testReplaceQueueSubscribers() throws IOException {
-        String name = "my_queue_" + ts();
-        Queue queue = new Queue(client, name);
-
         QueueModel payload = new QueueModel();
         payload.addSubscriber(new Subscriber("http://localhost:3000", "test01"));
         payload.addSubscriber(new Subscriber("http://localhost:3030", "test02"));
@@ -619,9 +613,6 @@ public class IronMQTest {
      */
     @Test
     public void testUpdateQueueSubscribers() throws IOException {
-        String name = "my_queue_" + ts();
-        Queue queue = new Queue(client, name);
-
         QueueModel payload = new QueueModel();
         payload.addSubscriber(new Subscriber("http://localhost:3000", "test01"));
         payload.addSubscriber(new Subscriber("http://localhost:3030", "test02"));
@@ -704,9 +695,6 @@ public class IronMQTest {
      */
     @Test
     public void testAddSubscribers() throws IOException {
-        String name = "my_queue_" + ts();
-        Queue queue = new Queue(client, name);
-
         QueueModel payload = new QueueModel();
         payload.addSubscriber(new Subscriber("http://localhost:3001", "test01"));
         queue.update(payload);
@@ -730,9 +718,6 @@ public class IronMQTest {
      */
     @Test
     public void testReplaceSubscribers() throws IOException {
-        String name = "my_queue_" + ts();
-        Queue queue = new Queue(client, name);
-
         QueueModel payload = new QueueModel();
         payload.addSubscriber(new Subscriber("http://localhost:3001", "test01"));
         queue.update(payload);
@@ -748,9 +733,6 @@ public class IronMQTest {
     @Test
     @Ignore // there is a bug in implementation of ironmq
     public void testRemoveSubscribers() throws IOException {
-        String name = "my_queue_" + ts();
-        Queue queue = new Queue(client, name);
-
         QueueModel payload = new QueueModel();
         Subscriber[] subscribers = new Subscriber[]{
                 new Subscriber("http://localhost:3001", "test01"),

--- a/src/test/java/io/iron/ironmq/IronMQTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQTest.java
@@ -165,24 +165,6 @@ public class IronMQTest {
     }
 
     /**
-     * Test shows how to increase time of message reservation
-     * Expected that:
-     * - message will be available after 5 seconds (initial timeout is 5 seconds)
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Test
-    public void testReserveMessageWithTimeout() throws IOException, InterruptedException {
-        queue.push("Test message");
-        Message reservedFirstTime = queue.reserve(1, 30).getMessage(0);
-
-        Thread.sleep(32000);
-        Messages reservedAgain = queue.reserve(1);
-        Assert.assertEquals(1, reservedAgain.getSize());
-        Assert.assertEquals(reservedAgain.getMessage(0).getId(), reservedFirstTime.getId());
-    }
-
-    /**
      * This test shows how to peek a message from a queue
      * Expected that
      * - Messsage has id and body
@@ -333,65 +315,6 @@ public class IronMQTest {
 
         messages.getMessage(0).setReservationId(null);
         queue.deleteMessages(messages);
-    }
-
-    /**
-     * Test shows how to increase time of message reservation
-     * Expected that:
-     * - message will be available after 5 seconds (initial timeout is 5 seconds)
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Test
-    public void testTouchMessage() throws IOException, InterruptedException {
-        queue.push("Test message");
-        Message message = queue.reserve(1, 30).getMessage(0);
-
-        Thread.sleep(25000);
-        queue.touchMessage(message);
-        Thread.sleep(10000);
-        Assert.assertEquals(0, queue.reserve(1).getSize());
-    }
-
-    /**
-     * Test shows how to increase time of message reservation
-     * Expected that:
-     * - message will be available after 5 seconds (initial timeout is 5 seconds)
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Test
-    public void testTouchMessageWithTimeout() throws IOException, InterruptedException {
-        queue.push("Test message");
-        Message message = queue.reserve(1, 30).getMessage(0);
-        queue.touchMessage(message, 40);
-
-        Thread.sleep(35000);
-        Assert.assertEquals(0, queue.reserve(1).getSize());
-        Thread.sleep(10000);
-        Assert.assertEquals(1, queue.reserve(1).getSize());
-    }
-
-    /**
-     * Test shows how to touch a message multiple times.
-     * Expected that:
-     * - after second touch call message will have new reservation id
-     * - new reservation id will not equal to old one
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Test
-    public void testTouchMessageTwice() throws IOException, InterruptedException {
-        queue.push("Test message");
-        Message message = queue.reserve(1, 5).getMessage(0);
-
-        Thread.sleep(3500);
-        MessageOptions options1 = queue.touchMessage(message);
-        Thread.sleep(3500);
-        MessageOptions options2 = queue.touchMessage(message);
-
-        Assert.assertFalse(options1.getReservationId().equals(options2.getReservationId()));
-        Assert.assertEquals(message.getReservationId(), options2.getReservationId());
     }
 
     /**

--- a/src/test/java/io/iron/ironmq/IronMQTest.java
+++ b/src/test/java/io/iron/ironmq/IronMQTest.java
@@ -327,7 +327,7 @@ public class IronMQTest {
     @Test
     public void testReleaseMessage() throws IOException, InterruptedException {
         queue.push("Test message");
-        Message message = queue.reserve(1, 5).getMessage(0);
+        Message message = queue.reserve(1).getMessage(0);
 
         Thread.sleep(500);
         queue.releaseMessage(message);
@@ -583,9 +583,38 @@ public class IronMQTest {
     }
 
     /**
-     * This test shows how to update subscribers of a queue
+     * This test shows how to replace subscribers of a queue
      * Expected:
      * - old subscribers should be replaced by new subscribers
+     * @throws IOException
+     */
+    @Test
+    public void testReplaceQueueSubscribers() throws IOException {
+        String name = "my_queue_" + ts();
+        Queue queue = new Queue(client, name);
+
+        QueueModel payload = new QueueModel();
+        payload.addSubscriber(new Subscriber("http://localhost:3000", "test01"));
+        payload.addSubscriber(new Subscriber("http://localhost:3030", "test02"));
+        payload.addSubscriber(new Subscriber("http://localhost:3333", "test03"));
+        QueueModel info = queue.update(payload);
+
+        Assert.assertEquals(3, info.getPushInfo().getSubscribers().size());
+
+        ArrayList<Subscriber> subscribers = new ArrayList<Subscriber>();
+        subscribers.add(new Subscriber("http://localhost:3000", "test04"));
+        subscribers.add(new Subscriber("http://localhost:3030", "test05"));
+        queue.replaceSubscribers(subscribers);
+
+        QueueModel info2 = queue.getInfoAboutQueue();
+        Assert.assertEquals(2, info2.getPushInfo().getSubscribers().size());
+    }
+
+    /**
+     * This test shows how to update subscribers of a queue
+     * Expected:
+     * - old subscribers should be updated
+     * - one of 3 subscribers not affected by update should stay the same
      * @throws IOException
      */
     @Test
@@ -602,11 +631,15 @@ public class IronMQTest {
         Assert.assertEquals(3, info.getPushInfo().getSubscribers().size());
 
         ArrayList<Subscriber> subscribers = new ArrayList<Subscriber>();
-        subscribers.add(new Subscriber("http://localhost:3000", "test04"));
-        subscribers.add(new Subscriber("http://localhost:3030", "test05"));
-        QueueModel info2 = queue.updateSubscribers(subscribers);
+        subscribers.add(new Subscriber("http://localhost:3030", "test01"));
+        subscribers.add(new Subscriber("http://localhost:3030", "test03"));
+        queue.updateSubscribers(subscribers);
 
-        Assert.assertEquals(2, info2.getPushInfo().getSubscribers().size());
+        QueueModel info2 = queue.getInfoAboutQueue();
+        Assert.assertEquals(3, info2.getPushInfo().getSubscribers().size());
+        for (int i = 0; i < info2.getSubscribers().size(); i++) {
+            Assert.assertEquals(info2.getSubscribers().get(i).getUrl(), "http://localhost:3030");
+        }
     }
 
     /**


### PR DESCRIPTION
* Added `mq-v3-aws-us-east-1.iron.io` as default v3 host (also removed other hosts from v1)
* Removed deprecated `touchMessage` method
* Removed deprecated `releaseMessage` method
* Added `timeout` parameter to `touchMessage` method
* Added 2 `updateSubscribers` overloads. Now all 3 methods calls `POST /queues/{Queue Name}/subscribers` according to specification
* Updated tests, separate into main tests and long-running tests
* Fixed `Queue.deletePushMessageForSubscriber() `

But, @featalion, @edsrzf, please, take a look.