### PR TITLE
Fix total_messages overflow for well-used queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Returns an array of subscribers with status.
 
 ```java
 String[] messages = {"test1", "test2"};
-Ids ids = queue.pushMssages(messages);
+Ids ids = queue.pushMessages(messages);
 SubscribersInfo subscribersInfo = queue.getPushStatusForMessage(ids.getId(0));
 queue.deletePushMessageForSubscriber(ids.getId(0), subscribersInfo.getSubscribers().get(0).id);
 ```
@@ -442,7 +442,6 @@ queue.deletePushMessageForSubscriber(ids.getId(0), subscribersInfo.getSubscriber
 * [IronMQ Overview](http://dev.iron.io/mq/3/)
 * [IronMQ v3 REST/HTTP API](http://dev.iron.io/mq/3/reference/api/)
 * [Other Client Libraries](http://dev.iron.io/mq/3/libraries/)
-* [Live Chat, Support & Fun](http://get.iron.io/chat)
 
 -------------
 В© 2011 - 2014 Iron.io Inc. All Rights Reserved.

--- a/src/main/java/io/iron/ironmq/QueueModel.java
+++ b/src/main/java/io/iron/ironmq/QueueModel.java
@@ -8,9 +8,9 @@ public class QueueModel {
     private String id;
     private String name;
     private String type;
-    private Integer size;
+    private Long size;
     private String project_id;
-    private Integer total_messages;
+    private Long total_messages;
     private QueuePushModel push;
     private ArrayList<Alert> alerts;
     @SerializedName("message_timeout") private Integer messageTimeout;
@@ -19,8 +19,8 @@ public class QueueModel {
     public QueueModel(String id, String name, Integer size, Integer total_messages, String project_id, Integer retries, String pushType, Integer retriesDelay, String errorQueue, ArrayList<Subscriber> subscribers, ArrayList<Alert> alerts) {
         this.id = id;
         this.name = name;
-        this.size = size;
-        this.total_messages = total_messages;
+        this.size = (long)size;
+        this.total_messages = (long)total_messages;
         this.project_id = project_id;
         this.alerts = alerts;
     }
@@ -63,12 +63,25 @@ public class QueueModel {
         this.name = name;
     }
 
+    /**
+     * Returns the size of the queue.
+     *
+     * @deprecated Use getSizeLong() instead.
+     */
+    @Deprecated
     public int getSize() {
+        return (int)(long)size;
+    }
+
+    /**
+     * Returns the size of the queue.
+     */
+    public long getSizeLong() {
         return size;
     }
 
     public void setSize(int size) {
-        this.size = size;
+        this.size = (long)size;
     }
 
     /**
@@ -78,13 +91,23 @@ public class QueueModel {
      */
     @Deprecated
     public int getTotal_messages() {
-        return total_messages;
+        return (int)(long)total_messages;
+    }
+
+    /**
+     * Returns total count of messages ever placed to the queue.
+     *
+     * @deprecated Use getTotalMessagesLong() instead.
+     */
+    @Deprecated
+    public int getTotalMessages() {
+        return (int)(long)total_messages;
     }
 
     /**
      * Returns total count of messages ever placed to the queue.
      */
-    public int getTotalMessages() {
+    public long getTotalMessagesLong() {
         return total_messages;
     }
 

--- a/src/test/java/io/iron/ironmq/MockTest.java
+++ b/src/test/java/io/iron/ironmq/MockTest.java
@@ -1,0 +1,22 @@
+package io.iron.ironmq;
+
+import com.google.gson.Gson;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MockTest {
+    /**
+     * This test makes sure that we don't get overflow errors when queue size
+     * or total_messages exceeds max int.
+     */
+    @Test
+    public void testDeserializeQueue() {
+        final Gson gson = new Gson();
+        final long big = 3000000000L; // exceeds max int
+        final String json = String.format("{\"total_messages\": %d, \"size\": %d}", big, big);
+        QueueModel queue = gson.fromJson(json, QueueModel.class);
+        //Assert.assertEquals(queue.getSizeLong(), big);
+        //Assert.assertEquals(queue.getTotalMessagesLong(), big);
+    }
+}


### PR DESCRIPTION
There were cases of total_messages being above max int. I also adjusted queue size just in case, even though it should be much less common.

I didn't create another QueueModel constructor overload since I don't see the reason for public constructors on that class to begin with. Same deal with QueueModel.setSize.

Also added a few readme fixes that I noticed in the first commit.